### PR TITLE
fix: openbsd 7.7 cursig deep flag

### DIFF
--- a/src/sys/fs/hammer2/hammer2_subr.c
+++ b/src/sys/fs/hammer2/hammer2_subr.c
@@ -381,7 +381,7 @@ hammer2_signal_check(void)
 
 	bzero(&ctx, sizeof(ctx));
 
-	return (cursig(p, &ctx));
+	return (cursig(p, &ctx, 0));
 }
 
 const char *


### PR DESCRIPTION
This PR is just highlighting some incoming changes required to support OpenBSD 7.7


- cursig: the function signature has changed with the addition of the "deep" flag. I didn't explore too much what it means but seems likely it is meant to be 0 unless you really want the new functionality. The changes were introduced into openbsd with this commit https://github.com/openbsd/src/commit/3b30ff2ab7969af0fd9a5f043abb71c2592340bb